### PR TITLE
use async_foward_entry_setups instead of async_setup_platforms

### DIFF
--- a/custom_components/miner/__init__.py
+++ b/custom_components/miner/__init__.py
@@ -19,7 +19,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = MinerCoordinator(hass, entry)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "miner",
-  "hacs": "1.6.0",
+  "hacs": "1.6.1",
   "domains": ["sensor", "switch", "number"],
   "iot_class": "local_polling",
   "homeassistant": "0.118.0"


### PR DESCRIPTION
`async_setup_platforms` is now deprecated.

https://community.home-assistant.io/t/async-setup-platforms-deprecated/529444